### PR TITLE
Add documentation of new weighting schemes

### DIFF
--- a/glossary.rst
+++ b/glossary.rst
@@ -21,7 +21,11 @@ Retrieval, while others have a specific meaning in the context of Xapian.
  the original probabilistic weighting scheme, and recent TREC tests have shown
  BM25 to be the best of the known probabilistic weighting schemes.  It's
  sometimes known as "Okapi BM25" since it was first implemented in an
- academic IR system called Okapi.
+ academic IR system called Okapi. BM25+ is another weighting scheme derived from 
+ the BM25 weighting formula. It adds a lower-bound to Term Frequency normalization.
+ BM25+ is useful when there are very long documents in the collection as it gives proper 
+ weights to those documents when any query term occurs in them and thereby, minimizing
+ the chances of over-penalizing those very long documents.
 
 **Boolean Retrieval**
  Retrieving the set of documents that match a boolean query (e.g. a

--- a/howtos/weighting_scheme.rst
+++ b/howtos/weighting_scheme.rst
@@ -10,7 +10,8 @@ How to change how documents are scored
 
 The easiest way to change document scoring is to change, or tune,
 the weighting scheme in use; Xapian provides a number of weighting schemes,
-including ``BM25Weight``, ``BM25PlusWeight``, ``LMWeight``, ``TradWeight`` and ``BoolWeight``
+including ``BM25Weight``, ``BM25PlusWeight``, ``PL2Weight``, ``PL2PlusWeight``,
+``LMWeight``, ``TfIdfWeight``, ``TradWeight`` and ``BoolWeight``
 (the default is BM25Weight).
 
 You can also :ref:`implement your own <custom-weighting>`.
@@ -87,26 +88,44 @@ words are considered to occur independently.
 
 The Dirichlet prior method is one of the best performing language modeling approaches. Xapian
 now provides support for a modified Dirichlet prior method, namely Dir+ which is an improvement over
-the original Dirichlet prior method as it is particularly more effective across web collections
-with very long documents (where document length is much larger than average document length).
+the original as it is particularly more effective across web collections with very long documents
+(where document length is much larger than average document length).
 
 TfIdfWeight
 -----------
 
 TfIdfWeight implements the support for a number of `SMART normalization variants`_ of the tf-idf
-weighting scheme. These normalizations are specified by a three character string. The first letter
-in each string specifies the normalization for the term frequency component (wdfn), the second the
-normalization for the inverse document frequency component (idfn), and the third the normalization
-used for the document weight (wtn).
+weighting scheme. These normalizations are specified by a three character string:
 
-For more details on Xapian supported SMART tf-idf normalizations, please visit TfIdfWeight API documentation
-page `here`_. More recently supported normalization in TfIdfWeight is the pivoted (piv+) retrieval function
+| 1. The first letter in each string specifies the normalization for the term frequency component (wdfn),
+| 2. the second the normalization for the inverse document frequency component (idfn), and
+| 3. the third the normalization used for the document weight (wtn).
+
+Normalizations are specified by the first character of their name string:
+
+1. | "**n** one" : wdfn = wdf
+   | "**b** oolean" (or sometimes binary) : wdfn = 1 if term is present in document else 0.
+   | "**s** quare" : wdfn = wdf * wdf
+   | "**l** og" : wdfn = 1 + ln (wdf)
+   | "**P** ivoted" : wdfn = 1 + log (1 + log (wdf))
+
+2. | "**n** one" : idfn = 1
+   | "**t** fidf" : idfn = log (N / Termfreq) where N is the number of
+                    documents in collection and Termfreq is the number of documents
+   | "**p** rob" : idfn = log ((N - Termfreq) / Termfreq)
+   | "**f** req" : idfn = 1 / Termfreq
+   | "**s** quared" : idfn = log (N / Termfreq) ^ 2
+   | "**P** ivoted" : idfn = log ((N + 1) / Termfreq)
+
+3. | "**n** one" : wtn = wdfn * idfn
+   | "**P** ivoted" : wtn = wqf (wdfn * idfn* (1 - slope + (slope * normlen)) + delta * idfn)
+
+More recently supported normalization in TfIdfWeight is the pivoted (piv+) retrieval function
 which represents one of the best performing vector space models. Piv+ takes two parameters; slope and delta
 which are set to their default optimal values. You may want pass different candidate values ranging from 0.1
 to 1.5 and choose one which fits best to your system based upon corpus being used.
 
 .. _SMART normalization variants: http://nlp.stanford.edu/IR-book/html/htmledition/document-and-query-weighting-schemes-1.html
-.. _here: https://xapian.org/docs/apidoc/html/classXapian_1_1TfIdfWeight.html
 
 TradWeight
 ----------

--- a/howtos/weighting_scheme.rst
+++ b/howtos/weighting_scheme.rst
@@ -66,9 +66,9 @@ Proposed by Lv-Zhai, PL2PlusWeight is the modified lower-bounded PL2 retrieval f
 the Divergence from Randomness Framework with an additonal parameter delta in addition to the
 parameter c from the PL2 weighting function.
 
-Parmater delta is the pseudo tf value to control the scale of the tf lower bound.
-It can be tuned for e.g from 0.1 to 1.5 in increments of 0.1 or so. Although, PL2+ works effectively
-across collections with a fixed default value of 0.8.
+Parmater delta is the pseudo tf value to control the scale of the tf lower bound. It can be tuned
+for e.g from 0.1 to 1.5 in increments of 0.1 or so. Although, PL2+ works effectively across collections
+with a fixed default value of 0.8.
 
 LMWeight (Unigram language modelling)
 -------------------------------------
@@ -84,6 +84,29 @@ values which do a good job, using two stage smoothing.
 The UnigramLM weighting formula is based on an original approach by Bruce Croft.
 It uses statistical language modelling; 'unigram' in this case means that
 words are considered to occur independently.
+
+The Dirichlet prior method is one of the best performing language modeling approaches. Xapian
+now provides support for a modified Dirichlet prior method, namely Dir+ which is an improvement over
+the original Dirichlet prior method as it is particularly more effective across web collections
+with very long documents (where document length is much larger than average document length).
+
+TfIdfWeight
+-----------
+
+TfIdfWeight implements the support for a number of `SMART normalization variants`_ of the tf-idf
+weighting scheme. These normalizations are specified by a three character string. The first letter
+in each string specifies the normalization for the term frequency component (wdfn), the second the
+normalization for the inverse document frequency component (idfn), and the third the normalization
+used for the document weight (wtn).
+
+For more details on Xapian supported SMART tf-idf normalizations, please visit TfIdfWeight API documentation
+page `here`_. More recently supported normalization in TfIdfWeight is the pivoted (piv+) retrieval function
+which represents one of the best performing vector space models. Piv+ takes two parameters; slope and delta
+which are set to their default optimal values. You may want pass different candidate values ranging from 0.1
+to 1.5 and choose one which fits best to your system based upon corpus being used.
+
+.. _SMART normalization variants: http://nlp.stanford.edu/IR-book/html/htmledition/document-and-query-weighting-schemes-1.html
+.. _here: https://xapian.org/docs/apidoc/html/classXapian_1_1TfIdfWeight.html
 
 TradWeight
 ----------

--- a/howtos/weighting_scheme.rst
+++ b/howtos/weighting_scheme.rst
@@ -30,6 +30,23 @@ fiddly process to tune them so people tend not to bother.
 
 .. todo:: Say something more useful about tuning the parameters!
 
+BM25PlusWeight
+--------------
+
+The occurrences of a query term in very long documents may not be rewarded properly
+by BM25, and thus those very long documents could be overly penalized. In such cases, 
+the BM25+ weighting formula is a useful improvement over the existing BM25 weighting 
+formula. In BM25, it is easy to note that there is a strict upper bound (k1 + 1) for
+Term Frequency normalization. However, the other interesting direction, lower-bounding
+TF, has not been well addressed. 
+
+BM25+ was originally proposed by Lv-Zhai in CIKM11 paper: `Lower-Bounding Term Frequency
+Normalization`_. BM25+ was derived from BM25 by lower-bounding TF and using all of the
+parameters of BM25 with an additional parameter -- delta(δ). Experiments by Lv-Zhai have
+shown that BM25+ works very well with δ = 1.
+
+.. _Lower-Bounding Term Frequency Normalization: http://sifaka.cs.uiuc.edu/czhai/pub/cikm11-bm25.pdf
+
 LMWeight (Unigram language modelling)
 -------------------------------------
 

--- a/howtos/weighting_scheme.rst
+++ b/howtos/weighting_scheme.rst
@@ -47,6 +47,29 @@ shown that BM25+ works very well with δ = 1.
 
 .. _Lower-Bounding Term Frequency Normalization: http://sifaka.cs.uiuc.edu/czhai/pub/cikm11-bm25.pdf
 
+PL2Weight
+---------
+
+PL2Weight implements the representative scheme of the Divergence from Randomness Framework
+This weighting scheme is useful for tasks that require early precision. It uses the
+Poisson approximation of the Binomial Probabilistic distribution (P),the Laplace method
+to find the after-effect of sampling (L) and the second wdf normalization to normalize the
+wdf in the document to the length of the document (H2).
+
+Document weight is controlled by parameter c. The default value of 1 for c is suitable
+for longer queries but it may need to be changed for shorter queries.
+
+PL2PLusWeight
+-------------
+
+Proposed by Lv-Zhai, PL2PlusWeight is the modified lower-bounded PL2 retrieval function of
+the Divergence from Randomness Framework with an additonal parameter delta in addition to the
+parameter c from the PL2 weighting function.
+
+Parmater delta is the pseudo tf value to control the scale of the tf lower bound.
+It can be tuned for e.g from 0.1 to 1.5 in increments of 0.1 or so. Although, PL2+ works effectively
+across collections with a fixed default value of 0.8.
+
 LMWeight (Unigram language modelling)
 -------------------------------------
 

--- a/howtos/weighting_scheme.rst
+++ b/howtos/weighting_scheme.rst
@@ -10,7 +10,7 @@ How to change how documents are scored
 
 The easiest way to change document scoring is to change, or tune,
 the weighting scheme in use; Xapian provides a number of weighting schemes,
-including ``BM25Weight``, ``LMWeight``, ``TradWeight`` and ``BoolWeight``
+including ``BM25Weight``, ``BM25PlusWeight``, ``LMWeight``, ``TradWeight`` and ``BoolWeight``
 (the default is BM25Weight).
 
 You can also :ref:`implement your own <custom-weighting>`.


### PR DESCRIPTION
This PR updates documentation with the following weighting schemes :-
- BM25+
- PL2
- PL2+
- Dir+ 
- Tf-Idf (Piv+ normalization)

Sorry for the delay, the new semester has started. Had to sort things out there.
