### PR TITLE
Fix displayed C++ compile and execute commands

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -319,7 +319,7 @@ def xapian_code_example_command(ex):
     elif highlight_language == 'tcl':
         return "tclsh %s" % xapian_code_example_filename(ex)
     elif highlight_language == 'c++':
-        return "g++ `xapian-config --cxxflags` %s support.cc -o built/%s `xapian-config --libs`\n./%s" \
+        return "g++ `xapian-config --cxxflags` %s code/c++/support.cc -o code/c++/built/%s `xapian-config --libs`\n./code/c++/built/%s" \
             % (xapian_code_example_filename(ex), ex, ex)
     elif highlight_language == 'csharp':
         return "cli-csc -unsafe -target:exe -out:%s.exe %s -r:XapianSharp.dll\n./%s.exe" \


### PR DESCRIPTION
Nesting is used to generated different examples for different languages(The original intention was that you'd be able to download just the examples for a particular language, and so the nesting wouldn't be needed. However since we've neither done that, nor made anything other than the python-baed version available online, this is the sensible thing to do for now.). Changed the displayed compile and execution command lines for c++ examples as they were referring to wrong location for generating the output, wrong location of support.cc and wrong location in the execution command.