### PR TITLE
Provide working example commands for C++ and Java

### DIFF
--- a/code/java/delete1.java
+++ b/code/java/delete1.java
@@ -1,3 +1,5 @@
+package code.java;
+
 import org.xapian.WritableDatabase;
 import org.xapian.XapianConstants;
 

--- a/code/java/index1.java
+++ b/code/java/index1.java
@@ -1,3 +1,5 @@
+package code.java;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Scanner;
@@ -10,6 +12,8 @@ import org.xapian.TermGenerator;
 import org.xapian.WritableDatabase;
 import org.xapian.XapianConstants;
 import org.xapian.XapianJNI;
+
+import code.java.support;
 
 public class index1 {
 

--- a/code/java/search1.java
+++ b/code/java/search1.java
@@ -1,3 +1,5 @@
+package code.java;
+
 import org.xapian.Database;
 import org.xapian.Document;
 import org.xapian.Enquire;

--- a/code/java/support.java
+++ b/code/java/support.java
@@ -1,4 +1,6 @@
 /* Support code for Java examples */
+package code.java;
+
 import java.util.ArrayList;
 
 public class support {

--- a/conf.py
+++ b/conf.py
@@ -319,7 +319,7 @@ def xapian_code_example_command(ex):
     elif highlight_language == 'tcl':
         return "tclsh %s" % xapian_code_example_filename(ex)
     elif highlight_language == 'c++':
-        return "g++ `xapian-config --cxxflags` %s support.cc -o built/%s `xapian-config --libs`\n./%s" \
+        return "g++ `xapian-config --cxxflags` %s code/c++/support.cc -o %s `xapian-config --libs`\n./%s" \
             % (xapian_code_example_filename(ex), ex, ex)
     elif highlight_language == 'csharp':
         return "cli-csc -unsafe -target:exe -out:%s.exe %s -r:XapianSharp.dll\n./%s.exe" \

--- a/conf.py
+++ b/conf.py
@@ -325,7 +325,7 @@ def xapian_code_example_command(ex):
         return "cli-csc -unsafe -target:exe -out:%s.exe %s -r:XapianSharp.dll\n./%s.exe" \
             % (ex, xapian_code_example_filename(ex), ex)
     elif highlight_language == 'java':
-        return "javac %s\njava %s" \
+        return "javac %s\njava code.java.%s" \
             % (xapian_code_example_filename(ex), ex)
     else:
         print "Unhandled highlight_language '%s'" % highlight_language
@@ -555,8 +555,20 @@ class XapianCodeSnippet(CodeBlock):
 directives.register_directive('xapiancodesnippet', XapianCodeSnippet)
 
 class XapianInclude(Include):
+
+    option_spec = {
+        'optional': directives.flag,
+    }
+    option_spec.update(Include.option_spec)
+
     def run(self):
         self.arguments[0] = re.sub(r'\bLANGUAGE\b', highlight_language, self.arguments[0])
+        if 'optional' in self.options:
+            # We want to silently fail if we can't find the file.
+            # Don't bother to process this 'properly', because we should
+            # only use it with straightforward paths.
+            if not os.path.exists(directives.path(self.arguments[0])):
+                return []
         return super(XapianInclude, self).run()
 
 # Usage:

--- a/language_specific/java/running_examples.rst
+++ b/language_specific/java/running_examples.rst
@@ -1,22 +1,22 @@
-Since third-party Java libraries generally don't have a standard place
-to install them, you will likely have to set the ``CLASSPATH``
-variable appropriately to indicate that you wish to use the Xapian
-Java bindings.
+Since there isn't a standard location to install third-party Java
+libraries, you will likely have to set the ``CLASSPATH`` variable
+appropriately to indicate that you wish to use the Xapian Java
+bindings.
 
 There are two parts to the bindings: a jarfile (``xapian.jar``)
 containing the Java classes, and the JNI library (such as
-``libxapian_jni.so`` on linux, or ``libxapian_jni.jnilib`` on macOS)
+``libxapian_jni.so`` on Linux, or ``libxapian_jni.jnilib`` on macOS)
 that connects them to Xapian itself. The easiest way to get this
 working is to copy those two files to the top-level directory of this
 repository. If you built your own Java bindings, the files will be in
 ``java/built`` in the bindings source code. Then you can use the
-following classpath (if on linux)::
+following classpath (if on Linux)::
 
   xapian.jar:libxapian_jni.so:.
 
 If you set the ``CLASSPATH`` variable to this, then the example
 commands will work as shown. For instance, if you're using the
 ``bash`` shell, you should run the following before any example
-commands (again, on linux)::
+commands (again, on Linux)::
 
   export CLASSPATH=xapian.jar:libxapian_jni.so:.

--- a/language_specific/java/running_examples.rst
+++ b/language_specific/java/running_examples.rst
@@ -1,9 +1,22 @@
-Since third-party Java libraries generally don't have a standard place to install them, you will likely have to set the ``CLASSPATH`` variable appropriately to indicate that you wish to use the Xapian Java bindings.
+Since third-party Java libraries generally don't have a standard place
+to install them, you will likely have to set the ``CLASSPATH``
+variable appropriately to indicate that you wish to use the Xapian
+Java bindings.
 
-There are two parts to the bindings: a jarfile (``xapian.jar``) containing the Java classes, and the JNI library (``libxapian_jni.jnilib``) that connects them to Xapian itself. The easiest way to get this working is to copy those two files to the top-level directory of this repository. If you built your own Java bindings, the files will be in ``java/built`` in the bindings source code. Then you can use the following classpath::
+There are two parts to the bindings: a jarfile (``xapian.jar``)
+containing the Java classes, and the JNI library (such as
+``libxapian_jni.so`` on linux, or ``libxapian_jni.jnilib`` on macOS)
+that connects them to Xapian itself. The easiest way to get this
+working is to copy those two files to the top-level directory of this
+repository. If you built your own Java bindings, the files will be in
+``java/built`` in the bindings source code. Then you can use the
+following classpath (if on linux)::
 
-  xapian.jar:libxapian_jni.jnilib:.
+  xapian.jar:libxapian_jni.so:.
 
-If you set the ``CLASSPATH`` variable to this, then the example commands will work as shown. For instance, if you're using the ``bash`` shell, you should run the following before any example commands::
+If you set the ``CLASSPATH`` variable to this, then the example
+commands will work as shown. For instance, if you're using the
+``bash`` shell, you should run the following before any example
+commands (again, on linux)::
 
-  export CLASSPATH=xapian.jar:libxapian_jni.jnilib:.
+  export CLASSPATH=xapian.jar:libxapian_jni.so:.

--- a/language_specific/java/running_examples.rst
+++ b/language_specific/java/running_examples.rst
@@ -1,0 +1,9 @@
+Since third-party Java libraries generally don't have a standard place to install them, you will likely have to set the ``CLASSPATH`` variable appropriately to indicate that you wish to use the Xapian Java bindings.
+
+There are two parts to the bindings: a jarfile (``xapian.jar``) containing the Java classes, and the JNI library (``libxapian_jni.jnilib``) that connects them to Xapian itself. The easiest way to get this working is to copy those two files to the top-level directory of this repository. If you built your own Java bindings, the files will be in ``java/built`` in the bindings source code. Then you can use the following classpath::
+
+  xapian.jar:libxapian_jni.jnilib:.
+
+If you set the ``CLASSPATH`` variable to this, then the example commands will work as shown. For instance, if you're using the ``bash`` shell, you should run the following before any example commands::
+
+  export CLASSPATH=xapian.jar:libxapian_jni.jnilib:.

--- a/overview.rst
+++ b/overview.rst
@@ -123,6 +123,9 @@ examples, we provide the commands needed to compile (if necessary) and run
 the code described. These commands are intended to be run from the top-level
 directory of the source for this guide.
 
+.. xapianinclude:: language_specific/LANGUAGE/running_examples.rst
+   :optional:
+
 .. todo:: link to here from every howto and everything that needs the data files and example code
 
 Contributing

--- a/overview.rst
+++ b/overview.rst
@@ -87,27 +87,16 @@ Datasets and example code
 
 If you want to run the code we use to demonstrate Xapian's features
 (and we recommend you do), you'll need both the code itself and the
-two datasets we use.
+two datasets we use. You can grab the `source for this guide from github`_,
+which contains the example code in each language (in the ``code``
+subdirectory), and also the data files listed below (in the ``data``
+subdirectory).
 
-The example code is available in Python, PHP, C++ and Java so far, although
-there's only a complete set of examples for Python at present.
+.. _source for this guide from github: https://github.com/xapian/xapian-docsprint
 
-.. As mentioned before, you can get the `examples in
-.. Python`_, `in PHP`_, `in C++`_ and `in Java`, although only the Python versions
-.. are complete for now.
-
-.. .. _examples in Python: https://xapian.org/docs/examples/python.tgz
-.. .. _in PHP: https://xapian.org/docs/examples/php.tgz
-.. .. _in C++: https://xapian.org/docs/examples/c++.tgz
-.. .. _in Java: https://xapian.org/docs/examples/java.tgz
-
-.. todo:: finalise datasets and code and link to them from here
-
-For now, you'll want to grab the `documentation source from github`_ which
-contains the example code in each language, and also the data files listed
-in the next paragraph (both are in the "code" subdirectory).
-
-.. _documentation source from github: https://github.com/xapian/xapian-docsprint
+The example code is available in Python, PHP, C++ and Java so far,
+although there's only a complete set of examples for Python at
+present.
 
 The first dataset is the first 100 objects taken from museum
 catalogue data released by the `Science Museum
@@ -121,13 +110,18 @@ Commons license Attribution-NonCommercial-ShareAlike
 second under `Creative Commons Attribution-Share Alike 3.0
 <https://creativecommons.org/licenses/by-sa/3.0/>`_.
 
-These datasets are in the git repo which holds the source for this
-documentation - you can also view them online on `github
+If you haven't grabbed the git repository, you can also view these
+datasets oneline on `github
 <https://github.com/xapian/xapian-docsprint/tree/master/data>`_:
 
  * `100-objects-v1.csv <https://raw.githubusercontent.com/xapian/xapian-docsprint/master/data/100-objects-v1.csv>`_
  * `100-objects-v2.csv <https://raw.githubusercontent.com/xapian/xapian-docsprint/master/data/100-objects-v2.csv>`_
  * `states.csv <https://raw.githubusercontent.com/xapian/xapian-docsprint/master/data/states.csv>`_
+
+As we describe how to use Xapian, and show how to use it with practical code
+examples, we provide the commands needed to compile (if necessary) and run
+the code described. These commands are intended to be run from the top-level
+directory of the source for this guide.
 
 .. todo:: link to here from every howto and everything that needs the data files and example code
 


### PR DESCRIPTION
The previous C++ ones assumed something about code and data layout that
is simply not true. We've decided that we don't want to provide
downloads of code and data (as we initially planned), so explicitly
guide people in the overview to clone the repository from github,
and adjust the C++ build instructions to match that layout.

The previous Java ones wouldn't work without very careful setting of `CLASSPATH` to pick up both the code itself but also the JNI library and bindings jarfile.