### PR TITLE
Issue #27: Add Python3 installation command for Debian

### DIFF
--- a/overview.rst
+++ b/overview.rst
@@ -58,8 +58,7 @@ in Python or C++:
 
 .. code-block:: none
 
-    $ sudo apt-get install python-xapian
-    $ sudo apt-get install python3-xapian (For Python3)
+    $ sudo apt-get install python3-xapian
     $ sudo apt-get install libxapian-dev
 
 Packages of the PHP bindings aren't available due to a licence

--- a/overview.rst
+++ b/overview.rst
@@ -59,6 +59,7 @@ in Python or C++:
 .. code-block:: none
 
     $ sudo apt-get install python-xapian
+    $ sudo apt-get install python3-xapian (For Python3)
     $ sudo apt-get install libxapian-dev
 
 Packages of the PHP bindings aren't available due to a licence


### PR DESCRIPTION
#27 Added Python3 installation instructions for Debian since it is confusing for new users.